### PR TITLE
PyMEOS: Integration with shapely

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note: libgeos-dev might need to be installed on your system.
 
 ```python
 import datetime
-from pymeos import GeomPoint
+from shapely.geometry import Point
 from pymeos.temporal import TGeomPointInst, TGeomPointSeq
 
 
@@ -43,9 +43,9 @@ def datetime_utc(year, month, day, hour=0, minute=0, second=0):
 
 # Example creation of trajectory (temporal sequence of geometries)
 trajectory = TGeomPointSeq({
-    TGeomPointInst(GeomPoint(0, 0), datetime_utc(2012, 1, 1, 8, 0)),
-    TGeomPointInst(GeomPoint(2, 0), datetime_utc(2012, 1, 1, 8, 10)),
-    TGeomPointInst(GeomPoint(2, 1), datetime_utc(2012, 1, 1, 8, 15)),
+    TGeomPointInst(Point(0, 0), datetime_utc(2012, 1, 1, 8, 0)),
+    TGeomPointInst(Point(2, 0), datetime_utc(2012, 1, 1, 8, 10)),
+    TGeomPointInst(Point(2, 1), datetime_utc(2012, 1, 1, 8, 15)),
 })
 
 print(trajectory)

--- a/pymeos/include/geometry.hpp
+++ b/pymeos/include/geometry.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+#include <meos/types/geom/GeomPoint.hpp>
+
+namespace py = pybind11;
+
+namespace pybind11 {
+namespace detail {
+// Casting between GeomPoint and shapely.geometry.point.Point
+template <> class type_caster<GeomPoint> {
+public:
+  typedef GeomPoint type;
+  bool load(handle src, bool) {
+    if (!src) return false;
+    GeomPoint point(src.attr("x").cast<double>(), src.attr("y").cast<double>());
+    value = point;
+    return true;
+  }
+
+  static handle cast(const GeomPoint &src, return_value_policy policy, handle /* parent */) {
+    auto Point = py::module::import("shapely.geometry").attr("Point");
+    py::object p = Point(src.x(), src.y());
+    return p.inc_ref().ptr();
+  }
+  PYBIND11_TYPE_CASTER(type, _("shapely.geometry.point.Point"));
+};
+}  // namespace detail
+}  // namespace pybind11

--- a/pymeos/source/pybind.cpp
+++ b/pymeos/source/pybind.cpp
@@ -7,6 +7,7 @@
 
 #include "box_module.hpp"
 #include "common.hpp"
+#include "geometry.hpp"
 #include "io_module.hpp"
 #include "range_module.hpp"
 #include "temporal_module.hpp"
@@ -18,33 +19,6 @@ namespace py = pybind11;
 PYBIND11_MODULE(_pymeos, m) {
   // TODO will we ever get a chance to do finish_geos()?
   init_geos();
-
-  py::class_<GeomPoint>(m, "GeomPoint")
-      .def(py::init<std::string>())
-      .def(py::init<double, double>())
-      .def(py::init<std::string, int>())
-      .def(py::init<double, double, int>())
-      .def(py::init<GeomPoint>())
-      .def(py::self + py::self, py::arg("other"))
-      .def(py::self - py::self, py::arg("other"))
-      .def(py::self == py::self, py::arg("other"))
-      .def(py::self != py::self, py::arg("other"))
-      .def(py::self < py::self, py::arg("other"))
-      .def(py::self <= py::self, py::arg("other"))
-      .def(py::self > py::self, py::arg("other"))
-      .def(py::self >= py::self, py::arg("other"))
-      .def("__str__", &to_ostream<GeomPoint>)
-      .def("__repr__", &to_ostream<GeomPoint>)
-      .def("compare", &GeomPoint::compare, py::arg("other"))
-      .def_property_readonly("x", &GeomPoint::x)
-      .def_property_readonly("y", &GeomPoint::y)
-      .def_property_readonly("srid", &GeomPoint::srid)
-      .def("fromWKB", &GeomPoint::fromWKB)
-      .def("toWKB", &GeomPoint::toWKB)
-      .def("fromWKT", &GeomPoint::fromWKT)
-      .def("toWKT", &GeomPoint::toWKT)
-      .def("fromHEX", &GeomPoint::fromHEX)
-      .def("toHEX", &GeomPoint::toHEX);
 
   def_box_module(m);
   def_io_module(m);

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ keywords = mobility, movement, geotemporal, trajectory, geos, meos
 [options]
 setup_requires =
     pybind11~=2.5
+    Shapely~=1.7
 zip_safe = false
 packages = find:
 


### PR DESCRIPTION
Basically this is currently implemented by introducing a pybind11 [custom type caster](https://github.com/adonmo/meos/tree/shapely) to map from `GeomPoint` to `shapely.geometry.point.Point`. However, in the current state, it suffers from two major issues:

  1. Shapely's `Point` objects are not hashable, and hence we can't use it in many classes like InstantSet.
  2. Shapely's `Point` objects do not support attaching SRID information, but maybe [Shapely 2.0](https://github.com/Toblerity/Shapely/issues/962) might (possibly) change this.

This PR, when complete, closes https://github.com/adonmo/meos/issues/8